### PR TITLE
Update to OMERO 5.6 and Pom-SciJava 32

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>26.0.0</version>
+		<version>32.0.0-beta-5</version>
 		<relativePath />
 	</parent>
 
@@ -142,16 +142,6 @@
 		<dependency>
 			<groupId>org.scijava</groupId>
 			<artifactId>scijava-common</artifactId>
-		</dependency>
-
-		<!-- OMERO dependencies -->
-		<dependency>
-			<groupId>omero</groupId>
-			<artifactId>blitz</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>omero</groupId>
-			<artifactId>model-psql</artifactId>
 		</dependency>
 	</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>net.imagej</groupId>
 	<artifactId>imagej-omero-legacy</artifactId>
-	<version>0.1.3-SNAPSHOT</version>
+	<version>1.0.0-5.6-SNAPSHOT</version>
 
 	<name>ImageJ-OMERO Legacy</name>
 	<description>ImageJ 1.x support for ImageJ-OMERO.</description>

--- a/src/main/java/net/imagej/omero/legacy/ActiveROIPostprocessor.java
+++ b/src/main/java/net/imagej/omero/legacy/ActiveROIPostprocessor.java
@@ -61,14 +61,12 @@ public class ActiveROIPostprocessor extends AbstractPostprocessorPlugin {
 	@Parameter
 	private ROIService roiService;
 
-	private final static String ROI_KEY = "outputROIs";
-
 	@Override
 	@SuppressWarnings("unchecked")
 	public void process(final Module module) {
-		if (cache.get(ROI_KEY) == null) return;
-		final Object retrieve = cache.get(ROI_KEY);
-		cache.put(ROI_KEY, null);
+		if (cache.get(ROIConstants.OUTPUT_CACHE_KEY) == null) return;
+		final Object retrieve = cache.get(ROIConstants.OUTPUT_CACHE_KEY);
+		cache.put(ROIConstants.OUTPUT_CACHE_KEY, null);
 		final List<ModuleItem<?>> rois =
 			((ThreadLocal<List<ModuleItem<?>>>) retrieve).get();
 

--- a/src/main/java/net/imagej/omero/legacy/AttachROIPostprocessor.java
+++ b/src/main/java/net/imagej/omero/legacy/AttachROIPostprocessor.java
@@ -65,15 +65,14 @@ public class AttachROIPostprocessor extends AbstractPostprocessorPlugin {
 	@Parameter
 	private ROIService roiService;
 
-	private final static String ROI_KEY = "outputROIs";
 	private static final String ATTACH_IMAGE = "attachToImages";
 
 	@Override
 	@SuppressWarnings("unchecked")
 	public void process(final Module module) {
-		if (cache.get(ROI_KEY) == null) return;
+		if (cache.get(ROIConstants.OUTPUT_CACHE_KEY) == null) return;
 		final List<ModuleItem<?>> roiItems =
-			((ThreadLocal<List<ModuleItem<?>>>) cache.get(ROI_KEY)).get();
+			((ThreadLocal<List<ModuleItem<?>>>) cache.get(ROIConstants.OUTPUT_CACHE_KEY)).get();
 		final List<ModuleItem<?>> resolved = new ArrayList<>();
 
 		for (final ModuleItem<?> item : roiItems) {
@@ -85,7 +84,7 @@ public class AttachROIPostprocessor extends AbstractPostprocessorPlugin {
 
 		for (final ModuleItem<?> item : resolved)
 			roiItems.remove(item);
-		if (roiItems.isEmpty()) cache.put(ROI_KEY, null);
+		if (roiItems.isEmpty()) cache.put(ROIConstants.OUTPUT_CACHE_KEY, null);
 	}
 
 	// -- Helper methods --

--- a/src/main/java/net/imagej/omero/legacy/CacheROIPostprocessor.java
+++ b/src/main/java/net/imagej/omero/legacy/CacheROIPostprocessor.java
@@ -58,8 +58,6 @@ public class CacheROIPostprocessor extends AbstractPostprocessorPlugin {
 	@Parameter
 	private CacheService cache;
 
-	private final static String ROI_KEY = "outputROIs";
-
 	@Override
 	public void process(final Module module) {
 		final List<ModuleItem<?>> rois = new ArrayList<>();
@@ -74,10 +72,10 @@ public class CacheROIPostprocessor extends AbstractPostprocessorPlugin {
 			}
 		}
 
-		if (cache.get(ROI_KEY) != null) throw new IllegalArgumentException(
+		if (cache.get(ROIConstants.OUTPUT_CACHE_KEY) != null) throw new IllegalArgumentException(
 			"Unexpected cached ROIs!");
 		if (!rois.isEmpty()) {
-			cache.put(ROI_KEY, ThreadLocal.withInitial(() -> rois));
+			cache.put(ROIConstants.OUTPUT_CACHE_KEY, ThreadLocal.withInitial(() -> rois));
 		}
 	}
 

--- a/src/main/java/net/imagej/omero/legacy/LegacyOMEROROIService.java
+++ b/src/main/java/net/imagej/omero/legacy/LegacyOMEROROIService.java
@@ -102,8 +102,8 @@ public class LegacyOMEROROIService extends DefaultROIService {
 	// -- Helper methods --
 
 	private void addROIs(final ImgPlus<?> img, final ROITree rp) {
-		if (img.getProperties().get("rois") != null) {
-			final ROITree currentROIs = (ROITree) img.getProperties().get("rois");
+		if (img.getProperties().get(ROIService.ROI_PROPERTY) != null) {
+			final ROITree currentROIs = (ROITree) img.getProperties().get(ROIService.ROI_PROPERTY);
 			if (!currentROIs.equals(rp)) {
 				final List<TreeNode<?>> currentChildren = currentROIs.children();
 				for (final TreeNode<?> child : rp.children()) {
@@ -112,7 +112,7 @@ public class LegacyOMEROROIService extends DefaultROIService {
 				}
 			}
 		}
-		else img.getProperties().put("rois", rp);
+		else img.getProperties().put(ROIService.ROI_PROPERTY, rp);
 	}
 
 	// NB: We cannot type this method on ij.* classes.

--- a/src/main/java/net/imagej/omero/legacy/LegacyOMEROROIService.java
+++ b/src/main/java/net/imagej/omero/legacy/LegacyOMEROROIService.java
@@ -104,10 +104,12 @@ public class LegacyOMEROROIService extends DefaultROIService {
 	private void addROIs(final ImgPlus<?> img, final ROITree rp) {
 		if (img.getProperties().get("rois") != null) {
 			final ROITree currentROIs = (ROITree) img.getProperties().get("rois");
-			final List<TreeNode<?>> currentChildren = currentROIs.children();
-			for (final TreeNode<?> child : rp.children()) {
-				child.setParent(currentROIs);
-				currentChildren.add(child);
+			if (!currentROIs.equals(rp)) {
+				final List<TreeNode<?>> currentChildren = currentROIs.children();
+				for (final TreeNode<?> child : rp.children()) {
+					child.setParent(currentROIs);
+					currentChildren.add(child);
+				}
 			}
 		}
 		else img.getProperties().put("rois", rp);

--- a/src/main/java/net/imagej/omero/legacy/LegacyOMEROROIService.java
+++ b/src/main/java/net/imagej/omero/legacy/LegacyOMEROROIService.java
@@ -27,9 +27,6 @@ package net.imagej.omero.legacy;
 
 import java.util.List;
 
-import ij.ImagePlus;
-import ij.gui.Overlay;
-
 import net.imagej.Dataset;
 import net.imagej.ImgPlus;
 import net.imagej.roi.DefaultROIService;
@@ -43,6 +40,9 @@ import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.service.Service;
 import org.scijava.util.TreeNode;
+
+import ij.ImagePlus;
+import ij.gui.Overlay;
 
 /**
  * A {@link ROIService} for working with ROIs in OMERO and imagej-legacy.

--- a/src/main/java/net/imagej/omero/legacy/LegacyOMEROROIService.java
+++ b/src/main/java/net/imagej/omero/legacy/LegacyOMEROROIService.java
@@ -119,14 +119,14 @@ public class LegacyOMEROROIService extends DefaultROIService {
 	// Otherwise, the ij1-patcher may fail to patch ImageJ1.
 	private void addROIs(final Object image, final Object rois) {
 		if (!(image instanceof ImagePlus)) {
-			throw new IllegalStateException("Non-ImagePlus image: " +
-				image.getClass().getName());
+			throw new IllegalStateException("Non-ImagePlus image: " + image.getClass()
+				.getName());
 		}
 		if (!(rois instanceof Overlay)) {
-			throw new IllegalStateException("Non-Overlay rois: " +
-				rois.getClass().getName());
+			throw new IllegalStateException("Non-Overlay rois: " + rois.getClass()
+				.getName());
 		}
-		final ImagePlus imp  = (ImagePlus) image;
+		final ImagePlus imp = (ImagePlus) image;
 		final Overlay overlay = (Overlay) rois;
 
 		if (imp.getOverlay() != null) {

--- a/src/main/java/net/imagej/omero/legacy/ROIConstants.java
+++ b/src/main/java/net/imagej/omero/legacy/ROIConstants.java
@@ -1,0 +1,11 @@
+
+package net.imagej.omero.legacy;
+
+/**
+ * Constants used with ROIs
+ */
+public class ROIConstants {
+	
+	public static final String OUTPUT_CACHE_KEY = "outputROIs";
+
+}

--- a/src/main/java/net/imagej/omero/legacy/convert/AbstractIJRoiToMaskPredicate.java
+++ b/src/main/java/net/imagej/omero/legacy/convert/AbstractIJRoiToMaskPredicate.java
@@ -128,7 +128,7 @@ public abstract class AbstractIJRoiToMaskPredicate<R extends Roi, M extends Mask
 	 * @param ijRoi the {@link Roi} key entry to update
 	 */
 	private void omeroMapping(final ij.gui.Roi ijRoi) {
-		final Set<Object> keys = omero.getROIMappingKeys();
+		final Set<Object> keys = omero.roiCache().getROIMappingKeys();
 
 		if (ijRoi.getProperty(ID_KEY) == null || ijRoi.getProperty(ID_KEY)
 			.isEmpty()) ijRoi.setProperty(ID_KEY, Long.toString(legacyRoi

--- a/src/main/java/net/imagej/omero/legacy/convert/IJROIToMaskPredicateWrappers.java
+++ b/src/main/java/net/imagej/omero/legacy/convert/IJROIToMaskPredicateWrappers.java
@@ -25,13 +25,6 @@
 
 package net.imagej.omero.legacy.convert;
 
-import ij.gui.OvalRoi;
-import ij.gui.PointRoi;
-import ij.gui.PolygonRoi;
-import ij.gui.Roi;
-import ij.gui.ShapeRoi;
-import ij.gui.TextRoi;
-
 import net.imagej.legacy.convert.roi.RoiToMaskIntervalConverter;
 import net.imagej.legacy.convert.roi.ShapeRoiToMaskRealIntervalConverter;
 import net.imagej.legacy.convert.roi.box.RoiToBoxConverter;
@@ -60,6 +53,13 @@ import org.scijava.convert.ConvertService;
 import org.scijava.convert.Converter;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
+
+import ij.gui.OvalRoi;
+import ij.gui.PointRoi;
+import ij.gui.PolygonRoi;
+import ij.gui.Roi;
+import ij.gui.ShapeRoi;
+import ij.gui.TextRoi;
 
 /**
  * {@link Converter}s for converting {@link ij.gui.Roi} to


### PR DESCRIPTION
This brings `imagej-omero-legacy` to the latest OMERO and ImageJ2 API

See also https://github.com/imagej/imagej-omero/pull/109